### PR TITLE
Changes for PHP 8.2 update

### DIFF
--- a/wp-content/plugins/homepage-builder/includes/admin-page.php
+++ b/wp-content/plugins/homepage-builder/includes/admin-page.php
@@ -140,6 +140,7 @@ function display_posts_element(array $args)
 
 $id = $args['post_id'];
 $title = $args['post_title'];
+$post_output = '';
 $post_output .= '<input id="'. $id .'" name="'. $id .'" class="'. $id .'" name="post" data-type="addThis" data-sort-position="0" data-image-position="0" data-name="'. $title .'" data-ID="' . $id .'" data-post-type="post" type="checkbox" value="1" '. checked(1, get_option($id), false) .'>';
     		$post_output .= '<label class="description">'. $title .'</label><br>';
     		print $post_output;

--- a/wp-content/themes/beyond/components/post/content-search.php
+++ b/wp-content/themes/beyond/components/post/content-search.php
@@ -20,7 +20,7 @@
 	
 	<div class="entry-thumb">
 
-	<?php echo get_the_post_thumbnail( $page->ID, 'thumbnail' ); ?>
+	<?php echo get_the_post_thumbnail( get_the_ID(), 'thumbnail' ); ?>
 
 		
 	</div>

--- a/wp-content/themes/beyond/functions.php
+++ b/wp-content/themes/beyond/functions.php
@@ -184,6 +184,9 @@ function beyond_scripts()
         wp_enqueue_script('comment-reply');
     }
 
+    $theme = wp_get_theme();
+    $theme_version = $theme->get( 'Version' );
+
     // wp datatables
     wp_enqueue_script( 'beyond-datatables-js', 'https://cdn.datatables.net/v/bs/dt-1.10.12/datatables.min.js', array(), $theme_version, true );
     wp_enqueue_style( 'beyond-style-datatables', 'https://cdn.datatables.net/1.10.22/css/jquery.dataTables.min.css', array(), $theme_version );
@@ -316,7 +319,7 @@ add_action('admin_init', 'my_meta_init');
 function my_meta_init()
 {
     // checks for post/page ID
-    $post_id = $_GET['post'] ? $_GET['post'] : $_POST['post_ID'] ;
+    $post_id = isset($_GET['post']) ? $_GET['post'] : (isset($_POST['post_ID']) ? $_POST['post_ID'] : null);
 
     // check for a database
     $tags = wp_get_post_tags($post_id);
@@ -619,8 +622,6 @@ function my_meta_init()
             }
         }
     }
-
-    add_action('save_post', 'my_meta_save');
 }
 
 // apply tags to attachments


### PR DESCRIPTION
Several small fixes to clear warnings and get rid of a critical error when updating to PHP 8.2.

Of these, `add_action('save_post', 'my_meta_save');` was causing a critical error and removing that line fixes it. There is no `my_meta_save` function. We're already using `add_action('save_post', 'hhs_repeatable_meta_box_save');` that handles saving post meta data.

The other fixes clear PHP warnings.
- `$post_output` had to be initialized with an empty string in the homepage-builder plugin.
- `$page` wasn't defined in `content-search.php`. Replaced with `get_the_ID()`.
- In `functions.php`, explicitly grab the theme version and on line 322, check if the array keys are set before trying to access them.